### PR TITLE
Move archive roles to provision module

### DIFF
--- a/modules/archive/main.tf
+++ b/modules/archive/main.tf
@@ -34,36 +34,15 @@ resource "google_storage_bucket" "archive" {
   }
 }
 
-resource "google_project_iam_custom_role" "archive_object_writer" {
-  role_id     = "archive_object_writer"
-  title       = "Archive object writer role"
-  description = "Allows writing objects to the archive bucket"
-  permissions = [
-    "storage.objects.create",
-    "storage.multipartUploads.create",
-    "storage.multipartUploads.abort",
-    "storage.multipartUploads.listParts",
-  ]
-}
-
 resource "google_storage_bucket_iam_member" "archive_writer" {
   bucket = google_storage_bucket.archive.name
-  role   = google_project_iam_custom_role.archive_object_writer.id
+  role   = "${data.google_project.project.id}/roles/archive_object_writer"
   member = "serviceAccount:tenant-host@${data.google_project.project.project_id}.iam.gserviceaccount.com"
-}
-
-resource "google_project_iam_custom_role" "archive_object_deleter" {
-  role_id     = "archive_object_deleter"
-  title       = "Archive object deleter role"
-  description = "Archive object deleter role to grant object delete access"
-  permissions = [
-    "storage.objects.delete"
-  ]
 }
 
 resource "google_storage_bucket_iam_member" "archive_deleter" {
   bucket = google_storage_bucket.archive.name
-  role   = google_project_iam_custom_role.archive_object_deleter.id
+  role   = "${data.google_project.project.id}/roles/archive_object_deleter"
   member = "serviceAccount:tenant-host@${data.google_project.project.project_id}.iam.gserviceaccount.com"
   condition {
     title       = "files that are updated"

--- a/modules/provision/main.tf
+++ b/modules/provision/main.tf
@@ -12,6 +12,27 @@ resource "google_project_service" "main_project_services" {
   disable_on_destroy = false
 }
 
+resource "google_project_iam_custom_role" "archive_object_writer" {
+  role_id     = "archive_object_writer"
+  title       = "Archive object writer role"
+  description = "Allows writing objects to the archive bucket"
+  permissions = [
+    "storage.objects.create",
+    "storage.multipartUploads.create",
+    "storage.multipartUploads.abort",
+    "storage.multipartUploads.listParts",
+  ]
+}
+
+resource "google_project_iam_custom_role" "archive_object_deleter" {
+  role_id     = "archive_object_deleter"
+  title       = "Archive object deleter role"
+  description = "Archive object deleter role to grant object delete access"
+  permissions = [
+    "storage.objects.delete"
+  ]
+}
+
 resource "google_project_iam_custom_role" "vespa_cloud_provisioner_role" {
   role_id     = "vespa.cloud.provisioner"
   title       = "Allow config servers to provision resources"


### PR DESCRIPTION
Roles are project wide, we cannot create the same roles for every zone the user defines, so move the role definition to the `provision` module.