### PR TITLE
Add template version label to storage_bucket

### DIFF
--- a/modules/archive/main.tf
+++ b/modules/archive/main.tf
@@ -30,7 +30,8 @@ resource "google_storage_bucket" "archive" {
   }
 
   labels = {
-    managedby = "vespa-cloud"
+    managedby              = "vespa-cloud"
+    vespa_template_version = var.zone.template_version
   }
 }
 

--- a/modules/archive/variables.tf
+++ b/modules/archive/variables.tf
@@ -2,12 +2,13 @@
 variable "zone" {
   description = "Vespa Cloud zone to bootstrap"
   type = object({
-    environment  = string,
-    region       = string,
-    gcp_region   = string,
-    gcp_zone     = string,
-    name         = string,
-    resource_ids = map(any),
-    is_cd        = bool,
+    environment      = string,
+    region           = string,
+    gcp_region       = string,
+    gcp_zone         = string,
+    name             = string,
+    resource_ids     = map(any),
+    is_cd            = bool,
+    template_version = string,
   })
 }

--- a/modules/zone/variables.tf
+++ b/modules/zone/variables.tf
@@ -2,13 +2,14 @@
 variable "zone" {
   description = "Vespa Cloud zone to bootstrap"
   type = object({
-    environment  = string,
-    region       = string,
-    gcp_region   = string,
-    gcp_zone     = string,
-    name         = string,
-    resource_ids = map(any),
-    is_cd        = bool,
+    environment      = string,
+    region           = string,
+    gcp_region       = string,
+    gcp_zone         = string,
+    name             = string,
+    resource_ids     = map(any),
+    is_cd            = bool,
+    template_version = string,
   })
 }
 

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,5 +1,6 @@
 
 locals {
+  template_version = "1_0_1" # '.' not allowed in labels
   all_zones = var.is_cd ? [
     { environment = "dev", gcp_region = "us-central1", gcp_zone = "us-central1-f" },
     { environment = "test", gcp_region = "us-central1", gcp_zone = "us-central1-f", },
@@ -16,10 +17,11 @@ locals {
   zones_by_env = {
     for zone in local.all_zones :
     zone.environment => merge({
-      name         = "${zone.environment}.${zone.gcp_zone}",
-      region       = "gcp-${zone.gcp_zone}",
-      is_cd        = var.is_cd,
-      resource_ids = module.provision.resource_ids,
+      name             = "${zone.environment}.${zone.gcp_zone}",
+      region           = "gcp-${zone.gcp_zone}",
+      is_cd            = var.is_cd,
+      resource_ids     = module.provision.resource_ids,
+      template_version = local.template_version,
     }, zone)...
   }
 }


### PR DESCRIPTION
Not many resources support labels in GCP. I tried to find all the resources that we use that support them and got this list:
```
$ git clone git@github.com:hashicorp/terraform-provider-google.git
Cloning into 'terraform-provider-google'...
...
$ for resource in $(grep -R '"labels":' terraform-provider-google | grep -Eo "/resource_[^.]+" | cut -c11-); do grep -qR "resource \"google_$resource\"" ~/dev/terraform-gcp-enclave/modules/ && echo $resource; done
storage_bucket
kms_crypto_key
```
`google-beta` provider additionally supports `labels` on `google_compute_address`