### PR TITLE
SSH need to add key to instance metadata

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -176,6 +176,7 @@ resource "google_project_iam_custom_role" "vespa_ssh" {
     "compute.instances.get",
     "compute.instances.osAdminLogin",
     "compute.instances.osLogin",
+    "compute.instances.setMetadata",
     "compute.instances.use",
     "compute.projects.get",
     "compute.regions.get",


### PR DESCRIPTION
Without this one gets:

```
Updating instance ssh metadata...failed.                                                                                                  
ERROR: (gcloud.compute.ssh) Could not add SSH key to instance metadata:
 - Required 'compute.instances.setMetadata' permission for 'projects/<project>/zones/<zone>/instances/<instance>'
```

However for another project it is not needed.  The latter has OS Login enabled at the org level, so perhaps that's the cause?