### PR TITLE
fix: enable dynamic port allocation on NAT resource

### DIFF
--- a/modules/zone/main.tf
+++ b/modules/zone/main.tf
@@ -110,12 +110,14 @@ resource "google_compute_router" "nat" {
 }
 
 resource "google_compute_router_nat" "nat" {
-  name                               = google_compute_router.nat.name
-  router                             = google_compute_router.nat.name
-  region                             = google_compute_router.nat.region
-  nat_ip_allocate_option             = "MANUAL_ONLY"
-  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
-  nat_ips                            = [google_compute_address.router_eip.id]
+  name                                = google_compute_router.nat.name
+  router                              = google_compute_router.nat.name
+  region                              = google_compute_router.nat.region
+  nat_ip_allocate_option              = "AUTO_ONLY"
+  source_subnetwork_ip_ranges_to_nat  = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  nat_ips                             = [google_compute_address.router_eip.id]
+  enable_dynamic_port_allocation      = true
+  enable_endpoint_independent_mapping = false
 }
 
 resource "google_compute_firewall" "allow_internal_traffic" {

--- a/modules/zone/variables.tf
+++ b/modules/zone/variables.tf
@@ -27,3 +27,9 @@ variable "archive_reader_members" {
   type        = list(string)
   default     = []
 }
+
+variable "nat_static_ip_count" {
+  description = "Number of static IPs to reserve for NAT gateways. Set to 0 to use ephemeral/dynamic IPs."
+  type        = number
+  default     = 0
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,6 @@
 locals {
   # major_minor_patch: major incremented on breaking changes, while patches are risk-free or important security fixes.
-  template_version = "1_2_0"
+  template_version = "1_3_0"
   zones_by_env = {
     for zone in var.all_zones :
     zone.environment => merge({


### PR DESCRIPTION
## What

- Updated NAT configuration to use AUTO_ONLY allocation and added dynamic port allocation settings.

## Why

- Improves port allocation and reduces the chances of resource exhaustion