### PR TITLE
chore(zone): improve upgrade experience to >= 1.3.x

### DIFF
--- a/modules/zone/moved.tf
+++ b/modules/zone/moved.tf
@@ -1,0 +1,5 @@
+# Handles upgrade to >= 1.3.0
+moved {
+  from = "google_compute_router_nat.nat"
+  to   = "google_compute_router_nat.nat_static[0]"
+}

--- a/modules/zone/variables.tf
+++ b/modules/zone/variables.tf
@@ -29,7 +29,13 @@ variable "archive_reader_members" {
 }
 
 variable "nat_static_ip_count" {
-  description = "Number of static IPs to reserve for NAT gateways. Set to 0 to use ephemeral/dynamic IPs. Changing this value will cause NAT gateway recreation and brief service interruption."
+  description =<<-EOT
+    Number of static IPs to reserve for NAT gateways.
+
+    Set to 0 to use ephemeral/dynamic IPs.
+    Important: Changing this value between 0 and a positive number (or vice versa) will trigger the replacement of the NAT gateway, which will cause a brief outage of outbound connectivity from the zone.
+  EOT
+
   type        = number
   default     = 0
 }

--- a/modules/zone/variables.tf
+++ b/modules/zone/variables.tf
@@ -29,7 +29,7 @@ variable "archive_reader_members" {
 }
 
 variable "nat_static_ip_count" {
-  description = "Number of static IPs to reserve for NAT gateways. Set to 0 to use ephemeral/dynamic IPs."
+  description = "Number of static IPs to reserve for NAT gateways. Set to 0 to use ephemeral/dynamic IPs. Changing this value will cause NAT gateway recreation and brief service interruption."
   type        = number
   default     = 0
 }


### PR DESCRIPTION
## What

* zone: refactor a single NAT resource into two separate `_dynamic` and `_static` resources
* zone: updates var var description indicating temporary service disruption on change
* zone: add a `moved` block to migrate the old NAT resource to the new static NAT resource, ensuring a smooth upgrade for users updating to version >= 1.3.0.

## Why

* This enables transitioning from Static IP to Dynamic IP allocation on the NAT 