### PR TITLE
[minor] Add automated release workflows and improve doc

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,52 @@
+# Contributing
+
+This repository uses `locals.template_version` in `main.tf` as the single source of truth for releases. Tags are created automatically from that value on merge to `main`.
+
+SemVer is required: `MAJOR.MINOR.PATCH` (no `v` prefix in the file).
+
+## Versioning and tagging policy
+
+- Regular PRs (most changes, including documentation):
+  - Bump `locals.template_version` in `main.tf`.
+  - The new version must be strictly greater than BOTH:
+    - The version on `origin/main`, and
+    - The latest existing tag (`v<MAJOR.MINOR.PATCH>`).
+  - CI (`version-check.yml`) enforces this and will fail if the bump is missing or not higher.
+
+- Minor/no-tag PRs (internal and trivial changes only):
+  - Do NOT bump `locals.template_version`.
+  - Mark intent by either:
+    - Adding the `no-tag` label, or
+    - Starting the PR title with `minor` or `[minor` (case-insensitive).
+  - CI will fail if `template_version` changes in such PRs.
+
+Important: Documentation changes are NOT considered minor and must bump the version.
+
+Examples of minor/no-tag changes:
+- Changes in `.github/` or `tools/` that do not affect module behavior
+- Comments or typo fixes in code
+- Refactoring that does not alter behavior nor documentation
+- Tests that do not affect module behavior
+
+Examples that REQUIRE a version bump (regular PRs):
+- Visible documentation changes (README, module docs, examples, etc.)
+- Behavioral changes to Terraform resources, variables, outputs or defaults
+- Any change that users should be aware of when consuming the module
+
+## What happens on merge
+
+- On push to `main`, `.github/workflows/tag-release.yml` creates a tag `v<template_version>` if and only if the version in `main.tf` is strictly greater than the latest existing tag.
+- If a PR is minor/no-tag and did not bump the version, no tag will be created.
+
+## Practical checklist
+
+Before requesting review:
+- [ ] Is this truly a minor/no-tag PR? If yes, ensure it does NOT include documentation changes, do not bump `template_version`, and mark the PR title/label accordingly.
+- [ ] Otherwise (regular PR), bump `locals.template_version` in `main.tf` to a higher SemVer than BOTH `origin/main` and the latest tag.
+- [ ] Ensure SemVer format `X.Y.Z` (no `v` prefix) in `main.tf`.
+- [ ] Leave `locals.template_version` key name and location unchanged; workflows depend on it.
+
+## Notes for maintainers
+
+- The PR check (`version-check.yml`) reads `main.tf` and verifies bump rules vs `origin/main` and the latest tag.
+- The tag workflow (`tag-release.yml`) only looks at `main.tf` on `main` and compares to existing tags. It does not consult PR metadata.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,21 @@
+<!--
+Versioning & tagging quick guide:
+
+- Regular PRs: bump `locals.template_version` in `main.tf`.
+- Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
+- README changes are NOT minor.
+- On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.
+
+See more details in .github/CONTRIBUTING.md.
+-->
+
+### Summary
+
+YOUR DESCRIPTION HERE
+
+### Intent (select one)
+
+- [ ] Regular - bumped version `locals.template_version` in `main.tf`
+- [ ] Minor/internal - no version bump (renaming/refactoring, comments, .github)
+
+First time contributor? Please check the policy in [CONTRIBUTING.md](https://github.com/vespa-cloud/terraform-google-enclave/blob/main/.github/CONTRIBUTING.md).

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,111 @@
+name: Tag release from main.tf template_version
+
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref_name }}
+  cancel-in-progress: false
+
+jobs:
+  tag-release:
+    name: Create release tag v<template_version>
+    runs-on: ubuntu-latest
+    outputs:
+      create: ${{ steps.check.outputs.create }}
+      tag: ${{ steps.check.outputs.tag }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Extract template_version from main.tf
+        id: version
+        run: |
+          FILE=main.tf
+          if [ ! -f "$FILE" ]; then
+            echo "❌ $FILE not found" >&2
+            exit 1
+          fi
+          TEMPLATE_VERSION=$(sed -nE 's/^[[:space:]]*template_version[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' "$FILE" | head -n1)
+          if [ -z "$TEMPLATE_VERSION" ]; then
+            echo "❌ Failed to parse template_version from main.tf" >&2
+            exit 1
+          fi
+          echo "value=$TEMPLATE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "Parsed template_version: $TEMPLATE_VERSION"
+
+      - name: Check if tag already exists and validate bump
+        id: check
+        run: |
+          VER='${{ steps.version.outputs.value }}'
+          TAG="v$VER"
+          echo "Proposed tag: $TAG"
+
+          if git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "Tag $TAG already exists; nothing to do."
+            echo "create=no" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          LATEST_TAG=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V | tail -n1 || true)
+          echo "🏷Latest existing tag (no v): ${LATEST_TAG:-none}"
+
+          if [ -n "$LATEST_TAG" ]; then
+            # Compare the template_version and latest tag (using sort -V for semantic versioning)
+            HIGHEST=$(printf '%s\n%s\n' "$LATEST_TAG" "$VER" | sort -V | tail -n1)
+            if [ "$HIGHEST" != "$VER" ]; then
+              echo "template_version ($VER) is not greater than the latest tag ($LATEST_TAG); skipping tag creation." >&2
+              echo "create=no" >> "$GITHUB_OUTPUT"
+              exit 0
+            fi
+          fi
+
+          echo "create=yes" >> "$GITHUB_OUTPUT"
+          echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+
+      - name: Create and push tag
+        if: steps.check.outputs.create == 'yes'
+        run: |
+          VER='${{ steps.version.outputs.value }}'
+          TAG="v$VER"
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git tag -a "$TAG" -m "Release $TAG"
+          git push origin "$TAG"
+          echo "🏷️Created and pushed tag️ $TAG"
+
+
+  publish-release:
+    name: Publish Release
+    runs-on: ubuntu-latest
+    needs: tag-release
+    if: needs.tag-release.outputs.create == 'yes'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - name: Create GitHub Release (gh)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          TAG: ${{ needs.tag-release.outputs.tag }}
+        run: |
+          set -euo pipefail
+          echo "Creating release for $TAG"
+          if gh release view "$TAG" >/dev/null 2>&1; then
+            echo "Release $TAG already exists; nothing to do."
+          else
+            gh release create "$TAG" \
+              --title "Release $TAG" \
+              --generate-notes
+            echo "✅ Created release $TAG"
+          fi

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -56,7 +56,7 @@ jobs:
           fi
 
           LATEST_TAG=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V | tail -n1 || true)
-          echo "🏷Latest existing tag (no v): ${LATEST_TAG:-none}"
+          echo "🏷 Latest existing tag (no v): ${LATEST_TAG:-none}"
 
           if [ -n "$LATEST_TAG" ]; then
             # Compare the template_version and latest tag (using sort -V for semantic versioning)
@@ -80,7 +80,7 @@ jobs:
           git config user.email "github-actions[bot]@users.noreply.github.com"
           git tag -a "$TAG" -m "Release $TAG"
           git push origin "$TAG"
-          echo "🏷️Created and pushed tag️ $TAG"
+          echo "🏷 Created and pushed tag️ $TAG"
 
 
   publish-release:

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -12,7 +12,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
         with:
           fetch-depth: 0
 

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -1,0 +1,133 @@
+name: PR Template version bump check
+
+on:
+  pull_request:
+    branches:
+      - main
+
+jobs:
+  check-template-version-bumped:
+    name: Ensure locals.template_version is bumped vs main and latest tag
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Compute minor/no-tag flag
+        id: pr_intent
+        env:
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          HAS_NO_TAG: ${{ contains(github.event.pull_request.labels.*.name, 'no-tag') }}
+        run: |
+          TITLE_LC=$(echo "${PR_TITLE:-}" | tr '[:upper:]' '[:lower:]')
+          if [ "${HAS_NO_TAG}" = "true" ] || [[ "$TITLE_LC" == minor* ]] || [[ "$TITLE_LC" == "[minor"* ]]; then
+            echo "minor_or_notag=true" >> "$GITHUB_OUTPUT"
+            echo "Computed minor/no-tag = true (title='$PR_TITLE', has_no_tag=$HAS_NO_TAG)"
+          else
+            echo "minor_or_notag=false" >> "$GITHUB_OUTPUT"
+            echo "Computed minor/no-tag = false (title='$PR_TITLE', has_no_tag=$HAS_NO_TAG)"
+          fi
+
+      - name: Extract template_version from PR (main.tf)
+        id: pr_version
+        run: |
+          FILE=main.tf
+          if [ ! -f "$FILE" ]; then
+            echo "❌ main.tf not found" >&2
+            exit 1
+          fi
+          TEMPLATE_VERSION=$(sed -nE 's/^[[:space:]]*template_version[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' "$FILE" | head -n1)
+          if [ -z "$TEMPLATE_VERSION" ]; then
+            echo "❌ Failed to parse template_version from PR main.tf" >&2
+            exit 1
+          fi
+          echo "value=$TEMPLATE_VERSION" >> "$GITHUB_OUTPUT"
+          echo "PR template_version: $TEMPLATE_VERSION"
+
+      - name: Fetch main branch
+        run: |
+          git fetch origin main --depth=1
+
+      - name: Extract template_version from origin/main
+        id: main_version
+        run: |
+          if ! git show origin/main:main.tf > /tmp/main.tf 2>/dev/null; then
+            echo "❌ origin/main:main.tf not found. The main branch must contain main.tf with template_version." >&2
+            exit 1
+          fi
+          MAIN_VERSION=$(sed -nE 's/^[[:space:]]*template_version[[:space:]]*=[[:space:]]*"([0-9]+\.[0-9]+\.[0-9]+)".*/\1/p' /tmp/main.tf | head -n1)
+          if [ -z "$MAIN_VERSION" ]; then
+            echo "❌ Failed to parse template_version from origin/main:main.tf" >&2
+            exit 1
+          fi
+          echo "Main branch template_version: ${MAIN_VERSION}"
+          echo "value=$MAIN_VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Determine latest v* tag (semver)
+        id: latest_tag
+        run: |
+          LATEST_TAG=$(git tag --list | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sed 's/^v//' | sort -V | tail -n1 || true)
+          echo "Latest tag (no v): ${LATEST_TAG:-none}"
+          echo "value=$LATEST_TAG" >> "$GITHUB_OUTPUT"
+
+      # Enforce NOT bumped for minor/no-tag PRs
+      - name: Enforce NOT bumped (minor/no-tag PRs)
+        if: steps.pr_intent.outputs.minor_or_notag == 'true'
+        run: |
+          PR_VER='${{ steps.pr_version.outputs.value }}'
+          MAIN_VER='${{ steps.main_version.outputs.value }}'
+          echo "Ensuring PR does NOT bump version: PR=$PR_VER, main=$MAIN_VER"
+          if [ "$PR_VER" != "$MAIN_VER" ]; then
+            echo "❌ locals.template_version changed in a minor/no-tag PR (PR=$PR_VER vs main=$MAIN_VER)." >&2
+            exit 1
+          fi
+          echo "✅ Version unchanged as expected for minor/no-tag PRs."
+
+      # Enforce bumped for regular PRs
+      - name: Enforce bump vs origin/main (regular PRs)
+        if: steps.pr_intent.outputs.minor_or_notag != 'true'
+        run: |
+          PR_VER='${{ steps.pr_version.outputs.value }}'
+          MAIN_VER='${{ steps.main_version.outputs.value }}'
+          echo "Comparing PR ($PR_VER) vs main ($MAIN_VER)"
+
+          if [ "$PR_VER" = "$MAIN_VER" ]; then
+            echo "❌ locals.template_version ($PR_VER) has not been bumped relative to main ($MAIN_VER)." >&2
+            exit 1
+          fi
+
+          HIGHEST=$(printf '%s\n%s\n' "$MAIN_VER" "$PR_VER" | sort -V | tail -n1)
+          if [ "$HIGHEST" != "$PR_VER" ]; then
+            echo "❌ locals.template_version ($PR_VER) is lower than main's version ($MAIN_VER)." >&2
+            exit 1
+          fi
+
+          echo "OK: PR version is greater than main."
+
+      - name: Enforce bump vs latest tag (regular PRs)
+        if: steps.pr_intent.outputs.minor_or_notag != 'true'
+        run: |
+          PR_VER='${{ steps.pr_version.outputs.value }}'
+          LATEST_TAG='${{ steps.latest_tag.outputs.value }}'
+          echo "Comparing PR ($PR_VER) vs latest tag (${LATEST_TAG:-none})"
+
+          if [ -z "$LATEST_TAG" ]; then
+            echo "No tags found; skipping tag comparison."
+            exit 0
+          fi
+
+          if [ "$PR_VER" = "$LATEST_TAG" ]; then
+            echo "❌ locals.template_version ($PR_VER) has not been bumped relative to the latest tag ($LATEST_TAG)." >&2
+            exit 1
+          fi
+
+          HIGHEST=$(printf '%s\n%s\n' "$LATEST_TAG" "$PR_VER" | sort -V | tail -n1)
+          if [ "$HIGHEST" != "$PR_VER" ]; then
+            echo "❌ locals.template_version ($PR_VER) is lower than the latest tag ($LATEST_TAG)." >&2
+            exit 1
+          fi
+
+          echo "✅ PR version is greater than the latest tag."

--- a/main.tf
+++ b/main.tf
@@ -227,6 +227,10 @@ resource "google_project_iam_custom_role" "archive_object_delete" {
 }
 
 locals {
+  # NOTE: Do not rename or move this variable!
+  # Used by github actions to tag releases. Bump for non-trivial changes.
+  template_version = "1.4.0"
+
   resource_ids = {
     archive_role_write  = google_project_iam_custom_role.archive_object_write.id,
     archive_role_delete = google_project_iam_custom_role.archive_object_delete.id

--- a/main.tf
+++ b/main.tf
@@ -229,7 +229,8 @@ resource "google_project_iam_custom_role" "archive_object_delete" {
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version = "1.4.0"
+  template_version     = "1.4.0"
+  template_version_gcp = replace(local.template_version, ".", "_")
 
   resource_ids = {
     archive_role_write  = google_project_iam_custom_role.archive_object_write.id,

--- a/outputs.tf
+++ b/outputs.tf
@@ -5,7 +5,7 @@ locals {
       name             = "${zone.environment}.${zone.gcp_zone}",
       region           = "gcp-${zone.gcp_zone}",
       resource_ids     = local.resource_ids,
-      template_version = local.template_version,
+      template_version = local.template_version_gcp,
     }, zone)...
   }
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,6 +1,4 @@
 locals {
-  # major_minor_patch: major incremented on breaking changes, while patches are risk-free or important security fixes.
-  template_version = "1_4_0"
   zones_by_env = {
     for zone in var.all_zones :
     zone.environment => merge({


### PR DESCRIPTION
  Port release automation from terraform-azure-enclave:
  - Add template_version to main.tf (single source of truth for releases)
  - Add tag-release.yml workflow to auto-create tags and GitHub releases on merge
  - Add version-check.yml workflow to enforce version bumps on PRs
  - Add CONTRIBUTING.md documenting the versioning policy
  - Add PR template

  The version format is changed from underscores (1_4_0) to semver dots (1.4.0)
  to match existing git tags and enable workflow compatibility.

NOTE: version bump check is expected to fail for this PR