### PR TITLE
Add GCP configuration for prod environment in us-east4

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -229,7 +229,7 @@ resource "google_project_iam_custom_role" "archive_object_delete" {
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version     = "1.4.0"
+  template_version     = "1.5.0"
   template_version_gcp = replace(local.template_version, ".", "_")
 
   resource_ids = {

--- a/variables.tf
+++ b/variables.tf
@@ -30,6 +30,7 @@ variable "all_zones" {
     { environment = "prod", gcp_region = "us-central1", gcp_zone = "us-central1-b" },
     { environment = "prod", gcp_region = "us-central1", gcp_zone = "us-central1-c" },
     { environment = "prod", gcp_region = "us-central1", gcp_zone = "us-central1-f" },
+    { environment = "prod", gcp_region = "us-east4", gcp_zone = "us-central1-f" },
     { environment = "prod", gcp_region = "europe-west3", gcp_zone = "europe-west3-b" },
 
     # deprecated in favor of dev zone - remove when bumping module to 2.x

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "all_zones" {
     { environment = "prod", gcp_region = "us-central1", gcp_zone = "us-central1-b" },
     { environment = "prod", gcp_region = "us-central1", gcp_zone = "us-central1-c" },
     { environment = "prod", gcp_region = "us-central1", gcp_zone = "us-central1-f" },
-    { environment = "prod", gcp_region = "us-east4", gcp_zone = "us-central1-f" },
+    { environment = "prod", gcp_region = "us-east4", gcp_zone = "us-east4-c" },
     { environment = "prod", gcp_region = "europe-west3", gcp_zone = "europe-west3-b" },
 
     # deprecated in favor of dev zone - remove when bumping module to 2.x


### PR DESCRIPTION
Added a new production environment configuration for GCP in the us-east4 region.

<!--
Versioning & tagging quick guide:

- Regular PRs: bump `locals.template_version` in `main.tf`.
- Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
- README changes are NOT minor.
- On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.

See more details in .github/CONTRIBUTING.md.
-->

### Summary

YOUR DESCRIPTION HERE

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (renaming/refactoring, comments, .github)

First time contributor? Please check the policy in [CONTRIBUTING.md](https://github.com/vespa-cloud/terraform-google-enclave/blob/main/.github/CONTRIBUTING.md).
