### PR TITLE
Relax versioning policy for minor doc changes and improve PR template

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -6,7 +6,7 @@ SemVer is required: `MAJOR.MINOR.PATCH` (no `v` prefix in the file).
 
 ## Versioning and tagging policy
 
-- Regular PRs (most changes, including documentation):
+- Regular PRs (most changes):
   - Bump `locals.template_version` in `main.tf`.
   - The new version must be strictly greater than BOTH:
     - The version on `origin/main`, and
@@ -20,18 +20,16 @@ SemVer is required: `MAJOR.MINOR.PATCH` (no `v` prefix in the file).
     - Starting the PR title with `minor` or `[minor` (case-insensitive).
   - CI will fail if `template_version` changes in such PRs.
 
-Important: Documentation changes are NOT considered minor and must bump the version.
-
 Examples of minor/no-tag changes:
 - Changes in `.github/` or `tools/` that do not affect module behavior
-- Comments or typo fixes in code
-- Refactoring that does not alter behavior nor documentation
+- Minor documentation changes (typo fixes, comment updates, small README tweaks)
+- Refactoring that does not alter behavior
 - Tests that do not affect module behavior
 
 Examples that REQUIRE a version bump (regular PRs):
-- Visible documentation changes (README, module docs, examples, etc.)
 - Behavioral changes to Terraform resources, variables, outputs or defaults
-- Any change that users should be aware of when consuming the module
+- New or removed variables, outputs, or resources
+- Any change that users should be aware of when consuming the module, including significant documentation updates
 
 ## What happens on merge
 
@@ -41,7 +39,7 @@ Examples that REQUIRE a version bump (regular PRs):
 ## Practical checklist
 
 Before requesting review:
-- [ ] Is this truly a minor/no-tag PR? If yes, ensure it does NOT include documentation changes, do not bump `template_version`, and mark the PR title/label accordingly.
+- [ ] Is this truly a minor/no-tag PR? If yes, do not bump `template_version`, and mark the PR title/label accordingly.
 - [ ] Otherwise (regular PR), bump `locals.template_version` in `main.tf` to a higher SemVer than BOTH `origin/main` and the latest tag.
 - [ ] Ensure SemVer format `X.Y.Z` (no `v` prefix) in `main.tf`.
 - [ ] Leave `locals.template_version` key name and location unchanged; workflows depend on it.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,21 +1,18 @@
+Describe your changes here.
+
 <!--
 Versioning & tagging quick guide:
 
 - Regular PRs: bump `locals.template_version` in `main.tf`.
 - Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
-- README changes are NOT minor.
 - On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.
 
 See more details in .github/CONTRIBUTING.md.
 -->
 
-### Summary
-
-YOUR DESCRIPTION HERE
-
 ### Intent (select one)
 
 - [ ] Regular - bumped version `locals.template_version` in `main.tf`
-- [ ] Minor/internal - no version bump (renaming/refactoring, comments, .github)
+- [ ] Minor/internal - no version bump (renaming/refactoring, comments, .github, minor docs)
 
 First time contributor? Please check the policy in [CONTRIBUTING.md](https://github.com/vespa-cloud/terraform-google-enclave/blob/main/.github/CONTRIBUTING.md).

--- a/.github/workflows/version-check.yml
+++ b/.github/workflows/version-check.yml
@@ -2,6 +2,7 @@ name: PR Template version bump check
 
 on:
   pull_request:
+    types: [opened, synchronize, reopened, labeled, unlabeled]
     branches:
       - main
 


### PR DESCRIPTION
Follow changes in the AWS repo

  Allow minor documentation changes (typo fixes, comment updates, small
  README tweaks) without requiring a version bump. Move the PR description
  placeholder above the comment block so developers see it first, and
  remove the Summary header.

### Intent (select one)

- [ ] Regular - bumped version `locals.template_version` in `main.tf`
- [x] Minor/internal - no version bump (renaming/refactoring, comments, .github)

