### PR TITLE
Add backup storage to GCP enclave zone module (V1)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -215,14 +215,25 @@ resource "google_project_iam_custom_role" "archive_object_delete" {
   ]
 }
 
+resource "google_project_iam_custom_role" "backup_object_expiry" {
+  role_id     = "backup_object_expiry"
+  title       = "Backup object expiry role"
+  description = "Allow listing and deleting from the backup bucket"
+  permissions = [
+    "storage.objects.delete",
+    "storage.objects.list",
+  ]
+}
+
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version     = "1.5.1"
+  template_version     = "1.6.0"
   template_version_gcp = replace(local.template_version, ".", "_")
 
   resource_ids = {
     archive_role_write  = google_project_iam_custom_role.archive_object_write.id,
-    archive_role_delete = google_project_iam_custom_role.archive_object_delete.id
+    archive_role_delete = google_project_iam_custom_role.archive_object_delete.id,
+    backup_role_expiry  = google_project_iam_custom_role.backup_object_expiry.id
   }
 }

--- a/modules/zone/backup.tf
+++ b/modules/zone/backup.tf
@@ -1,0 +1,62 @@
+# Backup storage for Vespa Cloud snapshots
+
+data "google_project" "backup" {}
+data "google_storage_project_service_account" "gcs_account" {}
+
+resource "google_storage_bucket" "backup" {
+  name                        = "backup-${data.google_project.backup.project_id}-${var.zone.environment}-gcp-${var.zone.gcp_zone}"
+  location                    = var.zone.gcp_region
+  force_destroy               = false
+  public_access_prevention    = "enforced"
+  uniform_bucket_level_access = true
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+    condition {
+      age = 365
+    }
+  }
+  encryption {
+    default_kms_key_name = google_kms_crypto_key.backup.id
+  }
+  depends_on = [google_kms_crypto_key_iam_binding.backup]
+}
+
+resource "google_storage_bucket_iam_member" "backup_creator" {
+  for_each = toset([
+    "roles/storage.objectCreator",
+    "roles/storage.objectViewer"
+  ])
+  bucket = google_storage_bucket.backup.name
+  role   = each.value
+  member = "serviceAccount:tenant-host@${data.google_project.backup.project_id}.iam.gserviceaccount.com"
+}
+
+resource "google_storage_bucket_iam_member" "backup_expirer" {
+  bucket = google_storage_bucket.backup.name
+  role   = var.zone.resource_ids.backup_role_expiry
+  member = "serviceAccount:vespa-cloud-provisioner@${var.vespa_cloud_project}.iam.gserviceaccount.com"
+}
+
+resource "google_kms_key_ring" "backup" {
+  name     = "host-backup-key-ring-${data.google_project.backup.project_id}-${var.zone.environment}-${var.zone.gcp_zone}"
+  location = var.zone.gcp_region
+}
+
+resource "google_kms_crypto_key" "backup" {
+  #checkov:skip=CKV_GCP_82: No prevent_destroy to allow tenants run terraform destroy
+  name            = "host-backup-key"
+  key_ring        = google_kms_key_ring.backup.id
+  rotation_period = "2592000s" # 30 days
+}
+
+resource "google_kms_crypto_key_iam_binding" "backup" {
+  crypto_key_id = google_kms_crypto_key.backup.id
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+
+  members = [
+    "serviceAccount:${data.google_storage_project_service_account.gcs_account.email_address}"
+  ]
+}

--- a/modules/zone/outputs.tf
+++ b/modules/zone/outputs.tf
@@ -14,3 +14,7 @@ output "archive_bucket" {
   description = "Name of Vespa Cloud Enclave archive bucket"
   value       = module.archive.bucket
 }
+output "backup_bucket" {
+  description = "Name of Vespa Cloud Enclave backup bucket"
+  value       = google_storage_bucket.backup.name
+}

--- a/modules/zone/variables.tf
+++ b/modules/zone/variables.tf
@@ -22,6 +22,12 @@ variable "zone_ipv4_cidr" {
   }
 }
 
+variable "vespa_cloud_project" {
+  description = "The project the Vespa Cloud provisioner resides in"
+  type        = string
+  default     = "vespa-external"
+}
+
 variable "archive_reader_members" {
   description = "List of members allowed to read archive bucket in the format `type:principal`. See https://registry.terraform.io/providers/hashicorp/google/latest/docs/resources/storage_bucket_iam#argument-reference for more details."
   type        = list(string)


### PR DESCRIPTION
Describe your changes here.

<!--
Versioning & tagging quick guide:

- Regular PRs: bump `locals.template_version` in `main.tf`.
- Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
- On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.

See more details in .github/CONTRIBUTING.md.
-->

### Intent (select one)

- [x] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

First time contributor? Please check the policy in [CONTRIBUTING.md](https://github.com/vespa-cloud/terraform-google-enclave/blob/main/.github/CONTRIBUTING.md).
