### PR TITLE
Use shorter key ring name. Limit is 63 chars (V2)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -228,7 +228,7 @@ resource "google_project_iam_custom_role" "backup_object_expiry" {
 locals {
   # NOTE: Do not rename or move this variable!
   # Used by github actions to tag releases. Bump for non-trivial changes.
-  template_version     = "2.1.1"
+  template_version     = "2.1.2"
   template_version_gcp = replace(local.template_version, ".", "_")
 
   globals = {

--- a/modules/zone/backup.tf
+++ b/modules/zone/backup.tf
@@ -41,7 +41,7 @@ resource "google_storage_bucket_iam_member" "backup_expirer" {
 }
 
 resource "google_kms_key_ring" "backup" {
-  name     = "host-backup-key-ring-${data.google_project.backup.project_id}-${var.zone.environment}-${var.zone.gcp_zone}"
+  name     = "${var.zone.environment}-${var.zone.gcp_zone}-vespa-cloud-backup-key"
   location = var.zone.regional.gcp_region
 }
 


### PR DESCRIPTION
With a long Google project name, the maximum key ring name length could easily be exceeded. 

<!--
Versioning & tagging quick guide:

- Regular PRs: bump `locals.template_version` in `main.tf`.
- Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
- On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.

See more details in .github/CONTRIBUTING.md.
-->

### Intent (select one)

- [X] Regular - bumped version `locals.template_version` in `main.tf`
- [ ] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

First time contributor? Please check the policy in [CONTRIBUTING.md](https://github.com/vespa-cloud/terraform-google-enclave/blob/main/.github/CONTRIBUTING.md).
