### PR TITLE
Use shorter key ring name. Limit is 63 chars (V1)

### DIFF
--- a/modules/zone/backup.tf
+++ b/modules/zone/backup.tf
@@ -41,7 +41,7 @@ resource "google_storage_bucket_iam_member" "backup_expirer" {
 }
 
 resource "google_kms_key_ring" "backup" {
-  name     = "host-backup-key-ring-${data.google_project.backup.project_id}-${var.zone.environment}-${var.zone.gcp_zone}"
+  name     = "${var.zone.environment}-${var.zone.gcp_zone}-vespa-cloud-backup-key"
   location = var.zone.gcp_region
 }
 


### PR DESCRIPTION
v1 equivalent of https://github.com/vespa-cloud/terraform-google-enclave/pull/57. No need to bump version number, as no new v1 releases have been made.