### PR TITLE
minor: Reuse zone name value in key ring name

### DIFF
--- a/modules/zone/backup.tf
+++ b/modules/zone/backup.tf
@@ -41,7 +41,7 @@ resource "google_storage_bucket_iam_member" "backup_expirer" {
 }
 
 resource "google_kms_key_ring" "backup" {
-  name     = "${var.zone.environment}-${var.zone.gcp_zone}-vespa-cloud-backup-key"
+  name     = "${local.zone_name}-vespa-cloud-backup-key"
   location = var.zone.regional.gcp_region
 }
 


### PR DESCRIPTION
As requested in https://github.com/vespa-cloud/terraform-google-enclave/pull/57#discussion_r3049773638

<!--
Versioning & tagging quick guide:

- Regular PRs: bump `locals.template_version` in `main.tf`.
- Minor PRs: do NOT bump version. Add the `no-tag` label or start the title with `minor` or `[minor` (case-insensitive).
- On merge to `main`, a tag `v<template_version>` is created automatically if the version increased.

See more details in .github/CONTRIBUTING.md.
-->

### Intent (select one)

- [ ] Regular - bumped version `locals.template_version` in `main.tf`
- [x] Minor/internal - no version bump (also add `no-tag` label or `minor` title prefix)

First time contributor? Please check the policy in [CONTRIBUTING.md](https://github.com/vespa-cloud/terraform-google-enclave/blob/main/.github/CONTRIBUTING.md).
